### PR TITLE
chore: Add icon name type for icon name completion

### DIFF
--- a/projects/angular-remix-icon/src/lib/angular-remix-icon.component.ts
+++ b/projects/angular-remix-icon/src/lib/angular-remix-icon.component.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import { Icons } from './icon.provider';
 import { upperCamelCase } from './utils/utils';
+import { IconName } from './icon-names';
 
 @Component({
   selector: 'rmx-icon',
@@ -29,7 +30,7 @@ export class AngularRemixIconComponent implements OnChanges {
     return `rmx-icon rmx-icon-${this.name}`;
   }
 
-  @Input() name!: string;
+  @Input() name!: IconName;
   constructor(
     private elem: ElementRef,
     private changeDetector: ChangeDetectorRef,

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -5,8 +5,13 @@ import * as upperCamelCase from 'uppercamelcase';
 const iconsSourceFolder = './node_modules/remixicon/icons';
 const iconsDestinationFolder = './projects/angular-remix-icon/src/lib/icons';
 const indexFile = './projects/angular-remix-icon/src/lib/icons.ts';
+const indexTypeFile = './projects/angular-remix-icon/src/lib/icon-names.ts';
 const iconTsTemplate = fs.readFileSync(
   `${__dirname}/template/icon.tpl`,
+  'utf-8'
+);
+const iconNameTypeTsTemplate = fs.readFileSync(
+  `${__dirname}/template/icon-name.tpl`,
   'utf-8'
 );
 
@@ -28,12 +33,15 @@ const iconTsTemplate = fs.readFileSync(
     return fs.readFileSync(filePath);
   };
 
-  await del(`${iconsDestinationFolder}`, { force: true });
-  await del(`${iconsDestinationFolder}/**/*`, { force: true });
-  await del(`${indexFile}`, { force: true });
+  await del(`${iconsDestinationFolder}`, {force: true});
+  await del(`${iconsDestinationFolder}/**/*`, {force: true});
+  await del(`${indexFile}`, {force: true});
+  await del(`${indexTypeFile}`, {force: true});
 
   fs.mkdirSync(`${iconsDestinationFolder}`);
   const categories = readCategories();
+
+  const iconNames: string[] = [];
   categories.forEach((category) => {
     fs.mkdirSync(`${iconsDestinationFolder}/${category}`);
     const iconsInCategory = readIconsInCategory(category);
@@ -63,6 +71,22 @@ const iconTsTemplate = fs.readFileSync(
         indexFile,
         `export { Ri${exportName} } from './icons/${category}/${iconName}';\n`
       );
+
+      iconNames.push(iconName);
     });
   });
+
+  const iconNamesForTSType = iconNames.reduce((result, next) => {
+    if (!result) {
+      return `\'${next}\'`;
+    }
+    return result + `\n | \'${next}\'`;
+  }, '');
+
+  const typeString = iconNameTypeTsTemplate
+    .replace(/__ICON_NAMES__/g, iconNamesForTSType);
+
+  console.log('WRITING...', `${indexTypeFile}`);
+
+  fs.writeFileSync(indexTypeFile, typeString);
 })();

--- a/scripts/template/icon-name.tpl
+++ b/scripts/template/icon-name.tpl
@@ -1,0 +1,1 @@
+export type IconName = __ICON_NAMES__;


### PR DESCRIPTION
Closes #9 
Allow IDE to show possible remix-icon names to prevent typo and so on