### PR TITLE
fix(ci): enable npm trusted publishing for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+          package-manager-cache: false  # never use caching in release builds
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -121,4 +121,6 @@ jobs:
           generate_release_notes: true
 
       - name: Publish to npm
-        run: pnpm publish ./dist/angular-remix-icon --access public --provenance
+        run: |
+          npm install -g npm@latest
+          pnpm publish ./dist/angular-remix-icon --access public

--- a/projects/angular-remix-icon/package.json
+++ b/projects/angular-remix-icon/package.json
@@ -18,6 +18,10 @@
     "url": "https://github.com/adisreyaj/angular-remix-icon/issues"
   },
   "homepage": "https://github.com/adisreyaj/angular-remix-icon/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adisreyaj/angular-remix-icon.git"
+  },
   "peerDependencies": {
     "@angular/common": ">=18.0.0 <22.0.0",
     "@angular/core": ">=18.0.0 <22.0.0"


### PR DESCRIPTION
## Summary

- Configures the release workflow for [npm trusted publishing](https://docs.npmjs.com/trusted-publishers#github-actions-configuration) (OIDC) instead of long-lived `NPM_TOKEN` secrets
- Upgrades npm before publish (requires npm ≥ 11.5.1 for OIDC) and disables package-manager cache on release builds
- Adds `repository` to the library `package.json` so npm can validate the GitHub repo during publish

## npm setup required

On [package settings → Trusted publishing](https://www.npmjs.com/package/angular-remix-icon/settings), configure:

| Field | Value |
|-------|--------|
| Provider | GitHub Actions |
| Organization or user | `adisreyaj` |
| Repository | `angular-remix-icon` |
| Workflow filename | `release.yml` |

Then re-run the Release workflow with **publish-only** to publish `8.2.0`.

## Test plan

- [ ] Trusted publisher saved on npmjs.com with workflow `release.yml`
- [ ] Merge and run Release workflow (`publish-only` mode)
- [ ] Confirm `angular-remix-icon@8.2.0` appears on npm with provenance