### PR TITLE
ci: GitHub Actions, Angular 21, pnpm, and npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+          package-manager-cache: false  # never use caching in release builds
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -121,4 +121,6 @@ jobs:
           generate_release_notes: true
 
       - name: Publish to npm
-        run: pnpm publish ./dist/angular-remix-icon --access public --provenance
+        run: |
+          npm install -g npm@latest
+          pnpm publish ./dist/angular-remix-icon --access public

--- a/projects/angular-remix-icon/package.json
+++ b/projects/angular-remix-icon/package.json
@@ -18,6 +18,10 @@
     "url": "https://github.com/adisreyaj/angular-remix-icon/issues"
   },
   "homepage": "https://github.com/adisreyaj/angular-remix-icon/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adisreyaj/angular-remix-icon.git"
+  },
   "peerDependencies": {
     "@angular/common": ">=18.0.0 <22.0.0",
     "@angular/core": ">=18.0.0 <22.0.0"


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflows for CI, releases, and automated icon updates
- Upgrades to Angular 21, migrates from npm to pnpm, and replaces Karma/TSLint with Vitest/ESLint/Playwright
- Regenerates icons for remixicon 4.9.1 and bumps library to v8.2.0
- Configures npm trusted publishing (OIDC) for releases — no long-lived `NPM_TOKEN` required

## npm setup required (before first release)

On [package settings → Trusted publishing](https://www.npmjs.com/package/angular-remix-icon/settings):

| Field | Value |
|-------|--------|
| Provider | GitHub Actions |
| Organization or user | `adisreyaj` |
| Repository | `angular-remix-icon` |
| Workflow filename | `release.yml` |

Then run the **Release** workflow with **publish-only** to publish `8.2.0`.

## Test plan

- [ ] CI workflow passes on merge
- [ ] Trusted publisher configured on npmjs.com
- [ ] Release workflow (`publish-only`) publishes `angular-remix-icon@8.2.0` with provenance
- [ ] Demo app and unit/e2e tests pass locally (`pnpm run test:ci`)